### PR TITLE
feat: Add npm publish workflow (Issue #5)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Closes #5

## Changes

- Added .github/workflows/publish.yml
- Triggers on release publish or manual dispatch
- Runs tests before publishing
- Publishes to npm with NPM_TOKEN secret

## To Publish

1. Add NPM_TOKEN secret to repo settings
2. Create a GitHub release
3. Workflow will publish to npm

package.json already has proper metadata from the modernization PR.

🧙‍♂️